### PR TITLE
Add a menu bar item to start and stop recording

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Builds are signed with a Developer ID certificate and notarized by Apple, with t
 
 On first launch DeskMate asks for your Anthropic API key and checks it against the API before saving. You can skip it — capture never touches the network and works with no key at all — and add one later in Settings.
 
-Then press **Start**, top right. That spawns the capture daemon; **Stop** ends it. Closing the window does not stop recording — stopping is meant to be a deliberate act.
+Then press **Start**, top right. That spawns the capture daemon; **Stop** ends it. The same two controls sit under the eye in the menu bar, so you can start and stop from whatever app you are in: the eye is filled while the recorder is capturing, outlined while it is running but you are idle, and struck through when nothing is recording. Closing the window leaves DeskMate in the menu bar and does not stop recording — stopping is meant to be a deliberate act.
 
 Requires **macOS 14 or later**. macOS prompts for Screen Recording on first capture, and for Accessibility if you want window titles. Grant them in System Settings → Privacy & Security, then Stop and Start again. The recorder asks under its own name, `DeskMateDaemon`, because it is a separate process from the window you are looking at.
 

--- a/Sources/DeskMateDashboard/DashboardApp.swift
+++ b/Sources/DeskMateDashboard/DashboardApp.swift
@@ -7,6 +7,8 @@ import SwiftUI
 /// accessory process: no Dock icon, no menu bar, and the window can't take
 /// focus. Promote to a regular app at startup.
 final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var windowObserver: NSObjectProtocol?
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         NSApp.setActivationPolicy(.regular)
         NSApp.activate(ignoringOtherApps: true)
@@ -16,9 +18,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // chrome (scrollbars, menus, focus rings) around a light glaze. Pin the
         // whole app to Aqua until a dark DSTheme exists.
         NSApp.appearance = NSAppearance(named: .aqua)
+
+        // With the menu bar item on, closing the dashboard doesn't quit — it
+        // retires the app to the menu bar. Step out of the Dock at that point
+        // so there isn't an icon for an app with no window; `DashboardWindow.show`
+        // steps back in. `willClose` fires before the window leaves
+        // `NSApp.windows`, so the check waits one hop of the main actor.
+        windowObserver = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification, object: nil, queue: .main
+        ) { note in
+            guard let closing = note.object as? NSWindow else { return }
+            // Delivered on the main queue, which is the main actor by another
+            // name; the assumption just lets the compiler see it.
+            MainActor.assumeIsolated {
+                guard DashboardWindow.isDashboard(closing) else { return }
+                DashboardWindow.noteClosed(closing)
+                Task { @MainActor in
+                    guard MenuBarPreference.isEnabled, !DashboardWindow.isPresent else { return }
+                    NSApp.setActivationPolicy(.accessory)
+                }
+            }
+        }
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+    /// Only when the menu bar item is off. With it on, DeskMate lives there
+    /// until you quit it, so that starting and stopping the recorder never
+    /// requires finding and opening the window first.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        !MenuBarPreference.isEnabled
+    }
+
+    /// A Dock click, Finder, Spotlight or `open -a` with nothing showing: the
+    /// window is minimized, or we're retired to the menu bar with no window.
+    /// SwiftUI would normally handle this itself, but it stops the moment the
+    /// delegate implements the method — and we have to, to get back into the
+    /// Dock first. A minimized window we can raise from here. No window at all
+    /// needs `openWindow`, which only the SwiftUI side has; the menu bar label
+    /// is listening, and it's the only way to be in that state.
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows: Bool) -> Bool {
+        guard !hasVisibleWindows else { return true }
+        if DashboardWindow.raiseExisting() { return false }
+        NotificationCenter.default.post(name: DashboardWindow.reopenRequested, object: nil)
+        return false
+    }
 }
 
 @main
@@ -26,14 +68,33 @@ struct DashboardApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
     @StateObject private var model = DashboardModel()
     @StateObject private var sharing = SharingModel(storage: DashboardModel.sharedStorage)
+    @AppStorage(MenuBarPreference.key) private var showMenuBarExtra = true
+    @Environment(\.openWindow) private var openWindow
 
     var body: some Scene {
-        WindowGroup("DeskMate") {
+        WindowGroup("DeskMate", id: DashboardWindow.id) {
             ContentView()
                 .environmentObject(model)
                 .environmentObject(sharing)
                 .frame(minWidth: 900, minHeight: 600)
         }
+        // The item can go away without the window being open: ⌘-drag it out
+        // of the menu bar while the app is retired there and SwiftUI flips the
+        // binding. That would leave a process with no window, no Dock icon and
+        // no menu bar item — running, and unreachable. Give it its window back.
+        .onChange(of: showMenuBarExtra) { _, shown in
+            guard !shown, !DashboardWindow.isPresent else { return }
+            DashboardWindow.show(using: openWindow)
+        }
+
+        // The recorder, reachable from any app. Shares the one model, so the
+        // icon and the title-bar dot can never disagree about what's running.
+        MenuBarExtra(isInserted: $showMenuBarExtra) {
+            RecorderMenu(model: model)
+        } label: {
+            RecorderMenuBarLabel(model: model)
+        }
+        .menuBarExtraStyle(.menu)
     }
 }
 
@@ -81,6 +142,12 @@ final class DashboardModel: ObservableObject {
     @Published var sessions: [Session] = []
     @Published var daemonStatus: DaemonStatus?
     @Published var recorderError: String?
+    /// Bumped on every failed start, even when the message is the same as last
+    /// time. `recorderError` alone can't be watched for that: SwiftUI compares
+    /// values across a frame, and nil → the same string inside one frame reads
+    /// as no change at all. The menu bar label watches this to surface failures
+    /// that happen with no window open.
+    @Published private(set) var recorderFailures = 0
     @Published var slices: [ActivitySlice] = []
     @Published var totalCaptures: Int = 0
     @Published var suggestions: [WorkflowSuggestion] = []
@@ -115,6 +182,8 @@ final class DashboardModel: ObservableObject {
     private let storage: Storage?
     private let stats: DashboardStats?
     private var statusPoll: Task<Void, Never>?
+    /// What the poll last saw, so it can publish the moment idleness changes.
+    private var wasIdle = false
     /// When the last query ran, so a foreground refresh can tell a genuine
     /// return to the app from a duplicate of a reload that just happened.
     private var lastReloadAt: Date?
@@ -124,9 +193,16 @@ final class DashboardModel: ObservableObject {
     /// True while the daemon is up but hasn't captured recently — it skips
     /// ticks when you're idle, so "running" and "capturing" are not the same
     /// thing and the indicator shouldn't pretend otherwise.
-    var isIdle: Bool {
-        guard let last = daemonStatus?.lastCaptureAt else { return isRecording }
-        return Date().timeIntervalSince(last) > Config.captureIntervalSeconds * 2
+    var isIdle: Bool { Self.isIdle(daemonStatus) }
+
+    /// Before the first capture the clock runs from launch instead: a recorder
+    /// that started a second ago is about to capture and shouldn't read as
+    /// idle, while one that has had two intervals and produced nothing — no
+    /// Screen Recording permission, typically — should.
+    static func isIdle(_ status: DaemonStatus?) -> Bool {
+        guard let status else { return false }
+        let reference = status.lastCaptureAt ?? status.startedAt
+        return Date().timeIntervalSince(reference) > Config.captureIntervalSeconds * 2
     }
 
     init() {
@@ -172,7 +248,15 @@ final class DashboardModel: ObservableObject {
                 guard let self else { return }
                 let status = DaemonControl.currentStatus()
                 await MainActor.run {
-                    if status != self.daemonStatus { self.daemonStatus = status }
+                    // Idle is derived from the clock, not from the status file:
+                    // when captures simply stop arriving nothing in `status`
+                    // changes, so comparing status alone would leave every
+                    // indicator saying "Recording" after you've walked away.
+                    let idle = Self.isIdle(status)
+                    if status != self.daemonStatus || idle != self.wasIdle {
+                        self.daemonStatus = status
+                        self.wasIdle = idle
+                    }
                 }
             }
         }
@@ -189,7 +273,7 @@ final class DashboardModel: ObservableObject {
             do {
                 _ = try DaemonControl.start()
             } catch {
-                recorderError = error.localizedDescription
+                failStart(error.localizedDescription)
                 return
             }
             // Give it a beat to publish, then reflect reality.
@@ -197,11 +281,15 @@ final class DashboardModel: ObservableObject {
                 try? await Task.sleep(for: .milliseconds(600))
                 self.daemonStatus = DaemonControl.currentStatus()
                 if self.daemonStatus == nil {
-                    self.recorderError =
-                        "The recorder exited immediately. Check \(DaemonControl.logURL.path)."
+                    self.failStart("The recorder exited immediately. Check \(DaemonControl.logURL.path).")
                 }
             }
         }
+    }
+
+    private func failStart(_ message: String) {
+        recorderError = message
+        recorderFailures += 1
     }
 
     /// Clustering is local and free — no API call, no cost — so it can run on
@@ -404,6 +492,23 @@ struct ContentView: View {
                 dashboard
             }
         }
+        // Above the setup/dashboard split, not inside the dashboard: the
+        // recorder can be started from the menu bar before setup is finished,
+        // and a failure there brings this window up to show why. A banner
+        // that only existed on the dashboard would leave that window blank.
+        .overlay(alignment: .bottom) {
+            if let err = model.recorderError {
+                DSBanner(
+                    title: "Recorder didn't start",
+                    message: err,
+                    tone: .critical,
+                    onDismiss: model.dismissRecorderError
+                )
+                .padding(DSTheme.default.space(3))
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+        .animation(DSMotion.present, value: model.recorderError)
         .dsTheme(.default)
     }
 
@@ -460,16 +565,10 @@ struct ContentView: View {
             model.reloadOnForeground()
         }
         .overlay(alignment: .bottom) {
-            if let err = model.recorderError {
-                DSBanner(
-                    title: "Recorder didn't start",
-                    message: err,
-                    tone: .critical,
-                    onDismiss: model.dismissRecorderError
-                )
-                .padding(DSTheme.default.space(3))
-                .transition(.move(edge: .bottom).combined(with: .opacity))
-            } else if let err = model.loadError {
+            // The recorder banner sits one level up, over setup as well; this
+            // one is the dashboard's own. Hidden while the recorder banner is
+            // up so the two never stack.
+            if model.recorderError == nil, let err = model.loadError {
                 DSBanner(
                     title: "Something went wrong",
                     message: err,
@@ -481,7 +580,6 @@ struct ContentView: View {
             }
         }
         .animation(DSMotion.present, value: model.loadError)
-        .animation(DSMotion.present, value: model.recorderError)
     }
 }
 

--- a/Sources/DeskMateDashboard/RecorderMenuBar.swift
+++ b/Sources/DeskMateDashboard/RecorderMenuBar.swift
@@ -1,0 +1,197 @@
+import AppKit
+import DeskMateCore
+import SwiftUI
+
+/// Whether DeskMate keeps an item in the menu bar.
+///
+/// Held in `UserDefaults` rather than `AppSettings`: that file exists so the
+/// daemon and the nightly summary can read the same switches as the dashboard,
+/// and neither of them has a menu bar. This is the dashboard's alone.
+///
+/// Defaults to on. A screen recorder you can only see by opening its window is
+/// a screen recorder you forget is running.
+enum MenuBarPreference {
+    static let key = "showMenuBarExtra"
+
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: key) as? Bool ?? true
+    }
+}
+
+/// The status item itself: one template glyph that says whether your screen is
+/// being watched right now.
+///
+/// Three states rather than two, matching the dot in the title bar: the daemon
+/// skips ticks while you're idle, so "running" and "capturing" are different
+/// things and the icon shouldn't pretend otherwise.
+struct RecorderMenuBarLabel: View {
+    @ObservedObject var model: DashboardModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        Image(systemName: symbolName)
+            .accessibilityLabel(accessibilityLabel)
+            // The label is the one view that's alive for as long as the item is
+            // in the menu bar, window or no window. So it owns two things the
+            // window used to own alone: keeping the daemon poll running, and
+            // making sure a failed start is seen. The window shows that error
+            // as a banner; started from the menu with no window open, the
+            // banner would land nowhere, so bring the window up to carry it.
+            // This is the only place that does so — a second path racing it
+            // inside the same frame opened two windows.
+            .onAppear { model.startPollingDaemon() }
+            .onChange(of: model.recorderFailures) { _, _ in
+                guard !DashboardWindow.isPresent else { return }
+                DashboardWindow.show(using: openWindow)
+            }
+            .onReceive(NotificationCenter.default.publisher(for: DashboardWindow.reopenRequested)) { _ in
+                DashboardWindow.show(using: openWindow)
+            }
+    }
+
+    private var symbolName: String {
+        guard model.isRecording else { return "eye.slash" }
+        return model.isIdle ? "eye" : "eye.fill"
+    }
+
+    private var accessibilityLabel: String {
+        guard model.isRecording else { return "DeskMate, not recording" }
+        return model.isIdle ? "DeskMate, recorder running but idle" : "DeskMate, recording"
+    }
+}
+
+/// What drops down from the status item.
+///
+/// A plain menu, not a popover with controls drawn in it: this is the one part
+/// of the app that lives outside the Celadon glaze, next to Wi-Fi and the
+/// clock, and it should look like it belongs there. Everything it offers is
+/// also in the window — the menu is the version you can reach without leaving
+/// whatever you were doing.
+struct RecorderMenu: View {
+    @ObservedObject var model: DashboardModel
+    @Environment(\.openWindow) private var openWindow
+
+    var body: some View {
+        // A disabled line rather than a header: it reads as status, not as a
+        // thing to click, and it's the first thing you see with the menu open.
+        Text(statusLine)
+
+        Button(model.isRecording ? "Stop Recording" : "Start Recording") {
+            model.toggleRecording()
+        }
+
+        Divider()
+
+        Button("Open DeskMate") {
+            DashboardWindow.show(using: openWindow)
+        }
+
+        Divider()
+
+        // Quitting the dashboard never stopped the recorder, and the menu bar
+        // doesn't change that: the daemon is its own process and stopping it
+        // is the explicit act above. The status line at the top says what
+        // you'd be leaving running.
+        Button("Quit DeskMate") {
+            NSApp.terminate(nil)
+        }
+        .keyboardShortcut("q")
+    }
+
+    /// Clock times, not "2m ago". The menu is rebuilt when the model publishes,
+    /// not when you open it, and the model publishes when the daemon writes or
+    /// idleness flips — so a relative time would be frozen at whichever of
+    /// those happened last and read as a lie ten minutes later. A clock time
+    /// stays true for as long as it's on screen.
+    private var statusLine: String {
+        guard let status = model.daemonStatus else {
+            // A failure only matters while nothing is running. Once a recorder
+            // is up — from here, the window, or a shell — the live state wins.
+            return model.recorderError == nil ? "Not recording" : "Recorder didn't start"
+        }
+        guard let last = status.lastCaptureAt else {
+            // Same clock the icon uses: outlined once the first capture is
+            // overdue. Without Screen Recording permission it never arrives,
+            // and "starting…" forever would be a lie.
+            return model.isIdle ? "Running · nothing captured yet" : "Recorder starting…"
+        }
+        if model.isIdle { return "Idle · last capture \(Self.clock(last))" }
+        return "Recording since \(Self.clock(status.startedAt))"
+    }
+
+    /// "3:10 PM" today, "Wed 3:10 PM" otherwise — the daemon can run for days.
+    private static func clock(_ date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return date.formatted(date: .omitted, time: .shortened)
+        }
+        return date.formatted(.dateTime.weekday(.abbreviated).hour().minute())
+    }
+}
+
+/// Opening and finding the dashboard window.
+///
+/// Lives here rather than on the App because both the menu and the delegate
+/// need it, and neither is the other's business.
+@MainActor
+enum DashboardWindow {
+    static let id = "dashboard"
+
+    /// Posted by the app delegate when the app is reopened with no window —
+    /// the delegate can't open one, and the menu bar label can.
+    static let reopenRequested = Notification.Name("DeskMate.dashboardReopenRequested")
+
+    /// The dashboard, minus the windows AppKit and SwiftUI open on our behalf:
+    /// the status item's own window, menus, tooltips. Those are borderless
+    /// panels; the dashboard is the titled one.
+    static func isDashboard(_ window: NSWindow) -> Bool {
+        window.styleMask.contains(.titled) && !(window is NSPanel)
+    }
+
+    /// Open, minimized, or hidden along with the app. `isVisible` alone is
+    /// false for all but the first, and treating the others as "no window"
+    /// would open a second one on top of them — or retire the app to the menu
+    /// bar with a window still in the Dock and no way to reach it.
+    static var isPresent: Bool { current != nil }
+
+    /// Windows that have been closed but that SwiftUI still holds onto. A
+    /// closed window and a window hidden with ⌘H both report `isVisible ==
+    /// false`; this is how the two are told apart while the app is hidden.
+    private static let closed = NSHashTable<NSWindow>.weakObjects()
+
+    static func noteClosed(_ window: NSWindow) {
+        closed.add(window)
+    }
+
+    private static var current: NSWindow? {
+        NSApp.windows.first {
+            isDashboard($0)
+                && ($0.isVisible || $0.isMiniaturized || (NSApp.isHidden && !closed.contains($0)))
+        }
+    }
+
+    /// Raise the window that exists — behind something, or in the Dock. Pure
+    /// AppKit, so the delegate can call it too. Returns false when there is no
+    /// window at all, the one case that needs SwiftUI's `openWindow`.
+    ///
+    /// Policy first: a window raised while the app is still an accessory comes
+    /// up without a Dock icon or main menu and can't take focus, which is the
+    /// same trap `applicationDidFinishLaunching` fixes.
+    @discardableResult
+    static func raiseExisting() -> Bool {
+        guard let window = current else { return false }
+        if NSApp.isHidden { NSApp.unhide(nil) }
+        NSApp.setActivationPolicy(.regular)
+        if window.isMiniaturized { window.deminiaturize(nil) }
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        return true
+    }
+
+    /// Bring the dashboard up from wherever the app is, opening one if needed.
+    static func show(using openWindow: OpenWindowAction) {
+        if raiseExisting() { return }
+        NSApp.setActivationPolicy(.regular)
+        openWindow(id: id)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}

--- a/Sources/DeskMateDashboard/SettingsView.swift
+++ b/Sources/DeskMateDashboard/SettingsView.swift
@@ -5,12 +5,14 @@ import SwiftUI
 /// Controls for the things this app does on its own.
 ///
 /// Everything here is off-by-consequence rather than off-by-default: these are
-/// switches for behaviour that already sends data somewhere, so each one says
-/// what it sends and where before asking you to decide.
+/// switches for behaviour that already does something on your behalf — sends
+/// data somewhere, or keeps running after you close the window — so each one
+/// says what that is before asking you to decide.
 struct SettingsView: View {
     @Environment(\.dsTheme) private var theme
     @State private var settings = AppSettings.load()
     @State private var saveError: String?
+    @AppStorage(MenuBarPreference.key) private var showMenuBarExtra = true
 
     @State private var storedKey = APIKeyStore.stored()
     @State private var keyDraft = ""
@@ -42,6 +44,7 @@ struct SettingsView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: theme.space(3)) {
                 apiKeyCard
+                menuBar
                 dailySummary
                 if let saveError {
                     DSBanner(title: "Couldn't save that", message: saveError, tone: .critical)
@@ -199,6 +202,32 @@ struct SettingsView: View {
             keyState = .idle
         } catch {
             keyState = .failed(error.localizedDescription)
+        }
+    }
+
+    /// The one switch here that isn't about sending data anywhere. It earns its
+    /// place because it changes what closing the window means, and that should
+    /// be said where it can be changed.
+    private var menuBar: some View {
+        DSCard {
+            VStack(alignment: .leading, spacing: theme.space(2)) {
+                DSToggle(
+                    title: "Show in the menu bar",
+                    subtitle: "Start and stop recording from any app.",
+                    isOn: $showMenuBarExtra)
+
+                DSDivider()
+
+                Text(showMenuBarExtra
+                     ? "While this is on, closing this window leaves DeskMate running in "
+                       + "the menu bar; Quit from that menu to close it entirely. "
+                       + "Neither stops the recorder — that's the Stop button."
+                     : "With this off, closing this window quits DeskMate. The recorder "
+                       + "keeps running either way — that's the Stop button.")
+                    .font(theme.body)
+                    .foregroundStyle(theme.inkSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
         }
     }
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -51,7 +51,9 @@ daemon to run:
 ```
 
 **4. Press Start**, top right. The dashboard spawns `DeskMateDaemon` for you
-and shows a red dot while it runs; **Stop** ends it.
+and shows a red dot while it runs; **Stop** ends it. The eye in the menu bar
+offers the same Start and Stop from inside any app, along with a status line
+that says whether the recorder is capturing, idle, or off.
 
 **5. Grant permissions.** macOS will prompt on first capture. Whatever you miss,
 the daemon reports at startup in
@@ -81,6 +83,12 @@ dashboard leaves recording running, because quitting a window you opened to
 read something should not silently stop collection. Stopping is an explicit act.
 If you move the binaries apart, point `DESKMATE_DAEMON_PATH` at the daemon.
 
+Closing the window does not quit DeskMate either. It retires to the menu bar —
+no Dock icon, no window — and comes back through *Open DeskMate* in that menu,
+or by launching it again (from Finder or Spotlight, if you installed the app).
+*Settings → Show in the menu bar* turns the item off; with it off, closing the
+window quits, and the recorder keeps running regardless.
+
 ## How it works
 
 ```
@@ -101,6 +109,8 @@ DeskMateDashboard  ──►  cluster into sessions  ──►  Claude API  ─�
 Two things keep a re-run cheap and quiet. Labels are cached in the database under a session id that is a stable hash of (start, bucket), so re-clustering doesn't pay Haiku twice for the same session. And a proposal matching a workflow you dismissed in the last 7 days is recorded as auto-dismissed rather than shown again.
 
 **Dashboard** (`DeskMateDashboard`) — four tabs. *Today* shows where your time went, *Workflows* holds the procedures you kept, *Suggestions* lists what Claude proposed (keep or dismiss), and *Settings* switches off anything the app does on its own. A fifth tab, *Team*, joins a shared hub and shows what you have shared to it; it is hidden behind `Config.sharingEnabled`, which is `false` — see [Team sharing](#team-sharing). The views are built from Celadon (青瓷), the design system under `Sources/DeskMateDashboard/DesignSystem`; `DESKMATE_DESIGN_MODE=1` replaces the whole window with its component catalog, which is how you read the design docs without an Xcode preview canvas.
+
+**Menu bar item** (`RecorderMenuBar.swift`) — a status icon and a plain menu that mirror the title-bar recorder control: Start or Stop, Open DeskMate, Quit. It shares the dashboard's `DashboardModel` and its two-second daemon poll, so the icon and the red dot cannot disagree. The poll republishes when idleness changes, not only when the status file does — nothing in that file changes when captures simply stop arriving, so without this every indicator would keep saying "Recording" after you walked away. A recorder start that fails while the window is closed brings the window up to show the error, since the banner it lands in has nowhere else to go.
 
 ## Privacy
 
@@ -240,7 +250,7 @@ half-written MP3.
 | `DeskMateCore` | `Config` (intervals, paths, exclusions), GRDB `Storage` + migrations, `Capture` / `Workflow` models, Vision OCR, redaction, daemon control, `APIKeyStore`, `SummaryJob`, team account and hub client |
 | `DeskMateDaemon` | capture loop, screenshot, idle detection, browser URL, permission check |
 | `DeskMateAnalyzer` | session clustering, Anthropic Messages API client, Haiku labeling, Opus pattern detection, automation planning |
-| `DeskMateDashboard` | SwiftUI app — Today, Workflows, Suggestions, Settings (+ Team, behind `Config.sharingEnabled`) — over the Celadon design system in `DesignSystem/` (tokens, primitives, components, catalog) |
+| `DeskMateDashboard` | SwiftUI app — Today, Workflows, Suggestions, Settings (+ Team, behind `Config.sharingEnabled`) — plus the menu bar item, over the Celadon design system in `DesignSystem/` (tokens, primitives, components, catalog) |
 | `DeskMateFixture` | test harness: fixture runs, comparator checks, sharing checks, hub round trips (see below) |
 | `DeskMateSummary` | the nightly activity summary that the launchd job runs |
 | `server/` | the team hub — FastAPI over Postgres, deployed separately ([its own README](server/README.md)) |


### PR DESCRIPTION
Adds a menu bar item so recording can be started and stopped from any app, without finding the DeskMate window first. That's v1. A "new suggestion" indicator is the obvious v2 and the label view is built to take it (notes at the bottom).

## What's in it

**Menu bar item** (`Sources/DeskMateDashboard/RecorderMenuBar.swift`, new)
- An eye that mirrors the title-bar dot: `eye.fill` while capturing, `eye` while the recorder is running but you're idle, `eye.slash` when nothing is recording. Template glyph, so it follows the menu bar's appearance.
- A plain `.menu`-style menu, not a popover, so it looks like it belongs next to Wi-Fi and the clock:
  - status line — "Recording since 3:10 PM", "Idle · last capture 3:42 PM", "Recording · starting…", "Not recording", or "Recorder didn't start". Clock times rather than "2m ago": the menu is rebuilt when the model publishes, not when you open it, so a relative time would freeze at the last publish and read as a lie ten minutes later.
  - **Start Recording** / **Stop Recording**
  - **Open DeskMate**
  - **Quit DeskMate** (⌘Q)
- Shares the dashboard's `DashboardModel` and its 2-second daemon poll, so the icon and the red dot can't disagree.

**Closing the window no longer quits** (`DashboardApp.swift`)
- With the item on, closing the last window retires the app to the menu bar: activation policy goes to `.accessory` (no Dock icon). *Open DeskMate*, or reopening from Finder/Spotlight, switches back to `.regular` and raises the existing window — behind something, minimized, or hidden with ⌘H — or opens one only when there is none. Closed windows that SwiftUI still holds are tracked so a hidden window can be told from a closed one; both report `isVisible == false`.
- `applicationShouldHandleReopen` posts a notification the menu-bar label turns into `openWindow(id:)`, because implementing that delegate method stops SwiftUI reopening the window itself, and the delegate has no `openWindow`.

**Settings → "Show in the menu bar"** (`SettingsView.swift`)
- Default on. Off removes the item and restores the previous behaviour: closing the window quits. `UserDefaults` rather than `AppSettings`, since the daemon and the nightly summary have no menu bar to care about. Dragging the item out of the menu bar with ⌘ flips the same switch.

**Three small model fixes that the menu bar made visible**
- The poll now republishes when the derived idle state flips, not only when `daemon.json` changes. Nothing in that file changes when captures simply stop arriving, so every indicator used to keep saying "Recording" after you walked away.
- Before the first capture, idleness is measured from launch. A recorder that never captures (no Screen Recording permission, typically) now reads as idle after two intervals instead of "starting…" forever, in the menu and the title bar alike.
- A recorder start that fails while no window is visible brings the window up so the existing red banner has somewhere to land. The banner moved above the setup/dashboard split so a first-run failure isn't shown as a blank setup screen. The label watches a `recorderFailures` counter rather than the error string: SwiftUI sees nil → the same message inside one frame as no change, so a repeated identical failure would otherwise be silent.

Docs: README and `docs/reference.md` updated where they describe Start/Stop and the window's lifetime.

## Verified

On macOS in dark mode, driving the running app through a temporary hook (since removed) and a stand-in `DeskMateDaemon` binary that publishes `daemon.json` the way the real one does:

- The status item's window reports `VibrantDark` even though the app pins `NSApp.appearance` to Aqua — AppKit manages the status bar's appearance itself, so the icon isn't black-on-black.
- Start and stop from the model with the window closed; the daemon is SIGTERMed and clears its status.
- Close → `.accessory`, app stays alive. Open → `.regular`, exactly one window; Open again → still one. Minimized window + Open → the same window comes back out of the Dock, no second one. ⌘H + Open → unhidden, still one window (also minimized-and-hidden).
- Fresh start → not idle before the first capture; captures paused → idle after two intervals.
- Item removed (the binding flipping to off) while retired to the menu bar → the window comes back and the app is `.regular` again, so there is no state with no window, no Dock icon and no item.
- Failed start with the window closed → window comes up with the error set. Both the synchronous failure (no daemon binary) and the asynchronous one (daemon exits immediately), twice in a row each → exactly one window every time.
- Captures paused for 70s → exactly one extra publish (the idle flip) with no status change; resumed → one more.
- Toggle off → closing quits. Pref off then on, relaunch → item is back.
- In a `.app` bundle: `open` while retired to the menu bar → `.regular` and one window, repeatable. With the item off and the window minimized, `open` brings the minimized window back rather than doing nothing (the delegate raises it directly, since no menu bar label exists to receive the reopen notification).
- `swift build` and `swift build -c release` both clean.

Not verified: pixels of the dropdown itself (no screen-recording permission on the machine used), and VoiceOver reading of the label.

## v2 and other ideas, not in this PR

- **New-suggestion indicator.** `RecorderMenuBarLabel` is the place: a badge variant of the glyph plus a "N new suggestions" line and *Open Suggestions* in the menu. The model already loads `suggestions`; a last-seen watermark in `UserDefaults` is all the state it needs.
- *Run Analysis* from the menu — wants a progress and error surface first.
- Today's capture count in the status line — needs a reload that isn't tied to the window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
